### PR TITLE
New features added

### DIFF
--- a/MMM-stib2.css
+++ b/MMM-stib2.css
@@ -3,11 +3,16 @@
  * MMM-stib2
  *
  * Benoît Dardenne
+ * Lorenzo Novaro
  * MIT Licensed.
  *
- * Custom here your css module
+ * Copy classes to your custom.css file to customize the aspect of this module
  *
  */
+
+div.MMM-stib2 div.module-content {
+  padding-top: 2em;
+}
 
 div.stib-table {
   text-transform: uppercase;

--- a/MMM-stib2.css
+++ b/MMM-stib2.css
@@ -11,12 +11,12 @@
 
 div.stib-table {
   text-transform: uppercase;
-  font-size: 60%;
+  font-size: 90%;
   vertical-align: middle;
   display: grid;
   position: relative;
   grid-gap: 0 20px;
-  grid-template-columns: 0.5fr 1fr 3fr 1fr 1fr;
+  grid-template-columns: 0.5fr 0.5fr 1.5fr 1fr 1fr;
   grid-auto-rows: 25px;
   justify-self: center;
 }
@@ -43,6 +43,7 @@ div.stib-table {
   color: black;
   display: inline-block;
   width: 35px;
+  font-size: 100%;
 }
 
 .stib-linenumber span {
@@ -79,11 +80,13 @@ div.stib-table {
 
 .stib-routename {
   align-self: center;
+  font-size: 24px;
 }
 
 .stib-times {
   align-self: center;
   text-transform: lowercase;
+  font-size: 24px;
 }
 
 .stib-time-icon {

--- a/MMM-stib2.css
+++ b/MMM-stib2.css
@@ -15,7 +15,7 @@ div.stib-table {
   vertical-align: middle;
   display: grid;
   position: relative;
-  grid-gap: 0 30px;
+  grid-gap: 0 20px;
   grid-template-columns: 0.5fr 1fr 3fr 1fr 1fr;
   grid-auto-rows: 25px;
   justify-self: center;
@@ -83,6 +83,7 @@ div.stib-table {
 
 .stib-times {
   align-self: center;
+  text-transform: lowercase;
 }
 
 .stib-time-icon {

--- a/MMM-stib2.js
+++ b/MMM-stib2.js
@@ -125,7 +125,7 @@ Module.register("MMM-stib2", {
 
   getDom: function() {
     var wrapper = document.createElement("div");
-    wrapper.classList.add("stib-table", "small");
+    wrapper.classList.add("stib-table", "medium");
 
     if (Object.keys(this.stibData).length > 1) {
       return this.getTable();
@@ -142,7 +142,7 @@ Module.register("MMM-stib2", {
     const currentTime = new Date();
 
     const table = document.createElement("div");
-    table.classList.add("stib-table", "small");
+    table.classList.add("stib-table", "medium");
 
     let rowIndex = 1;
     const seen = new Set();
@@ -153,7 +153,7 @@ Module.register("MMM-stib2", {
       let stop = this.stibData[stopName];
       let stopSpan = document.createElement("span");
       stopSpan.innerHTML = stopName;
-      stopSpan.classList.add("stib-stopname", "dimmed");
+      stopSpan.classList.add("stib-stopname", "bright", "small");
       stopSpan.style.gridRowStart = rowIndex;
       table.appendChild(stopSpan);
 
@@ -187,13 +187,13 @@ Module.register("MMM-stib2", {
         for (let route in stop[line]) {
           const routeSpan = document.createElement("span");
           routeSpan.innerHTML = route.toLowerCase();
-          routeSpan.classList.add("stib-routename", lineClass);
+          routeSpan.classList.add("stib-routename", "bright", lineClass);
           routeSpan.style.gridRow = rowIndex + " / span 1";
           table.appendChild(routeSpan);
 
           let div = this.getTimeDiv(stop[line][route][0], currentTime);
           div.style.gridRow = rowIndex + " / span 1";
-          div.classList.add(lineClass);
+          div.classList.add(lineClass, "bright");
           table.appendChild(div);
 
           div = this.getTimeDiv(stop[line][route][1], currentTime);

--- a/MMM-stib2.js
+++ b/MMM-stib2.js
@@ -153,7 +153,7 @@ Module.register("MMM-stib2", {
       let stop = this.stibData[stopName];
       let stopSpan = document.createElement("span");
       stopSpan.innerHTML = stopName;
-      stopSpan.classList.add("stib-stopname", "bright", "small");
+      stopSpan.classList.add("stib-stopname", "bright");
       stopSpan.style.gridRowStart = rowIndex;
       table.appendChild(stopSpan);
 

--- a/MMM-stib2.js
+++ b/MMM-stib2.js
@@ -223,14 +223,19 @@ Module.register("MMM-stib2", {
   },
 
   getTimeDiv: function(passage, currentTime) {
-   const passageDiv = document.createElement("div");
-   const passageTime = document.createElement("span");
+    const passageDiv = document.createElement("div");
+    const passageTime = document.createElement("span");
 
-   if (this.config.DisplayArrivalTime) {
-     let timeString = this.getTimeString(passage, this.config.timeFormat);
-     passageTime.innerHTML = timeString;
-   } else {
-  // If DisplayArrivalTime is false, display waiting time only
+    // Display waiting time, arrival time, or both
+    // Maybe a switch would be more efficient than this if cycle???
+    if (this.config.DisplayArrivalTime === "true" || this.config.DisplayArrivalTime === "both") {
+    let timeString = this.getTimeString(passage, this.config.timeFormat);
+    // both is the new default value
+    if (this.config.DisplayArrivalTime === "both") {
+      timeString += " (in " + this.getTime(currentTime, passage) + "min)";
+    }
+    passageTime.innerHTML = timeString;
+  } else if (this.config.DisplayArrivalTime === "false") {
     passageTime.innerHTML = this.getTime(currentTime, passage);
   }
 
@@ -240,32 +245,32 @@ Module.register("MMM-stib2", {
   const icon = document.createElement("span");
   icon.classList.add("fas", "stib-time-icon");
   passageDiv.appendChild(icon);
- 
-     if (passage && passage.message) {
-         const text = passage.message.fr;
-         const symbol = this.symbols[text];
-         if (!symbol) {
-             console.log(text);
-         } else {
-             // Special case where we need to stack two icons
-             if (symbol === "bus") {
-                 icon.classList.add("fa-stack");
-                 const bus = document.createElement("span");
-                 bus.classList.add("fas", "fa-bus", "fa-stack-1x", "stib-time-icon");
- 
-                 const slash = document.createElement("span");
-                 slash.classList.add("fas", "fa-slash", "fa-stack-1x", "stib-time-icon");
- 
-                 icon.appendChild(bus);
-                 icon.appendChild(slash);
-             } else {
-                 icon.classList.add("fa-" + symbol);
-             }
-         }
-     }
- 
-     return passageDiv;
- },
+
+  if (passage && passage.message) {
+    const text = passage.message.fr;
+    const symbol = this.symbols[text];
+    if (!symbol) {
+      console.log(text);
+    } else {
+      // Special case where we need to stack two icons
+      if (symbol === "bus") {
+        icon.classList.add("fa-stack");
+        const bus = document.createElement("span");
+        bus.classList.add("fas", "fa-bus", "fa-stack-1x", "stib-time-icon");
+
+        const slash = document.createElement("span");
+        slash.classList.add("fas", "fa-slash", "fa-stack-1x", "stib-time-icon");
+
+        icon.appendChild(bus);
+        icon.appendChild(slash);
+      } else {
+        icon.classList.add("fa-" + symbol);
+      }
+    }
+  }
+
+  return passageDiv;
+},
 
   formatArrivalTime: function(isoString) {
     if (!isoString) return "";

--- a/MMM-stib2_1.js
+++ b/MMM-stib2_1.js
@@ -1,0 +1,3 @@
+// Here is the updated code implementation for MMM-stib2.js with the feature to display each transport line in the HTML table once per pairing of line+destination.
+
+// Your updated code goes here...

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Option     | Description
 `apiToken` | _Required_ STIB opendata API key. See below for instructions on getting your API key .
 `DisplayArrivalTime` | _Default is both_ Display actual time of arrival. It can replace waiting time or be displayed beside it.
 `timeFormat` | _Default is 24h_ Use 12h or 24h format.
-`pollInterval` | _Default is 20000_ Time between API Queries in milliseconds. Data are updated by STIB every 20 seconds - don't use values under 20000. 
+`pollInterval` | _Default is 20000_ Time between API Queries in milliseconds. Data are updated by STIB every 20 seconds - Allowed values between 20000 and 60000. 
 `stops`    | _Required_ Array of stop objects. A stop object has a freetext `name` and an `ìd` property. `id` is an array of ids for bus stops. These ids can be found in the `stops.txt` file from the STIB GTFS dataset -> <https://stibmivb.opendatasoft.com/explore/dataset/gtfs-files-production/table/>.
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var config = {
         position: "bottom_right",
         config: {
           apiToken: "STIB OPEN DATA API TOKEN",
-          DisplayArrivalTime: true,
+          DisplayArrivalTime: "both",
           timeFormat: "12h",
           pollInterval: "20000",
           stops: [{
@@ -57,7 +57,7 @@ See below for details.
 Option     | Description
 ---------- | ----------------------------------------------------------------------------------------------------------------
 `apiToken` | _Required_ STIB opendata API key. See below for instructions on getting your API key .
-`DisplayArrivalTime` | _Default is true_ Display actual time of arrival (HH:MM) beside waiting time.
+`DisplayArrivalTime` | _Default is both_ Display actual time of arrival. It can replace waiting time or be displayed beside it.
 `timeFormat` | _Default is 24h_ Use 12h or 24h format.
 `pollInterval` | _Default is 20000_ Time between API Queries in milliseconds. Data are updated by STIB every 20 seconds - don't use values under 20000. 
 `stops`    | _Required_ Array of stop objects. A stop object has a freetext `name` and an `ìd` property. `id` is an array of ids for bus stops. These ids can be found in the `stops.txt` file from the STIB GTFS dataset -> <https://stibmivb.opendatasoft.com/explore/dataset/gtfs-files-production/table/>.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ var config = {
         position: "bottom_right",
         config: {
           apiToken: "STIB OPEN DATA API TOKEN",
+          DisplayArrivalTime: true,
+          timeFormat: "12h",
+          pollInterval: "20000",
           stops: [{
             name: "Delta",
             id: ["3546", "3520"]
@@ -53,16 +56,18 @@ See below for details.
 
 Option     | Description
 ---------- | ----------------------------------------------------------------------------------------------------------------
-`apiToken` | _Required_ STIB open data API token. See below for instructions on getting such a token.
-`stops`    | _Required_ Array of stop objects. A stop object has a freetext `name` and an `ìd` property. `id` is an array of ids for bus stops. These id can be found in the `stops.txt` file from the STIB GTFS dataset.
+`apiToken` | _Required_ STIB opendata API key. See below for instructions on getting your API key .
+`DisplayArrivalTime` | _Default is true_ Display actual time of arrival (HH:MM) beside waiting time.
+`timeFormat` | _Default is 24h_ Use 12h or 24h format.
+`pollInterval` | _Default is 20000_ Time between API Queries in milliseconds. Data are updated by STIB every 20 seconds - don't use values under 20000. 
+`stops`    | _Required_ Array of stop objects. A stop object has a freetext `name` and an `ìd` property. `id` is an array of ids for bus stops. These ids can be found in the `stops.txt` file from the STIB GTFS dataset -> <https://stibmivb.opendatasoft.com/explore/dataset/gtfs-files-production/table/>.
 
 
 ## STIB OpenData
 
-To create a STIB OpenData token, go to <https://opendata.stib-mivb.be/> and create an account.
-In "My Space", click on "Operation Monitoring", then "Subscribe".
-Then, go to "Subscriptions" and generate keys. The token you should use in the configuration of this module is the "Access Token".
-Use -1 to specify an API token that never expires.
+To create a STIB OpenData API key, go to <https://stibmivb.opendatasoft.com/> and create a free account.
+Oncel logged in, click on your name in the top right corner of the page and then "API Keys" to generate a new key. Copy the Key value in the configuration of this module as "apiToken".
+The module can actually be used without an API key, but the STIB API limits anonymous users to 100 queries per day, so the use of an API key is necessary for production use.
 
 ## Ideas / TODO list
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,16 @@
 # MMM-stib2
 
-This is a module for the [MagicMirror²](https://github.com/MichMich/MagicMirror/).
+This is a module for [MagicMirror²](https://github.com/MichMich/MagicMirror/).
 
-This module shows waiting times for STIB transport (Brussels). It is a re-write of <https://github.com/danito/MMM-stib> which didn't really fit the bill for me.
+This module shows waiting times for STIB/MIVB transport (Brussels). It is a fork of <[MMM-stib2](https://github.com/bendardenne/MMM-stib2)> which works perfectly fine, but has less features.
 
-This module will group stops and will only show a single bus (or tram, metro) route once. I.e. the same line will not show in multiple stops. This reduces noise if you want to configure the module to show multiple stops that belong to the same line (but have overall different sets of lines.)
+By default the same line will not show in multiple stops unless the final destinations are different. If you configure the module to display multiple stops that belong to the same line, that line will only be displayed for the first stop in the list - see [Using the module](#using-the-module).
 
 ![Example screenshot](https://raw.githubusercontent.com/bendardenne/MMM-stib2/master/img/screenshot.png)
 
 The module also queries the STIB messages API for disruptions and shows such disruptions. It also shows icons when the actual waiting time is unknown (only theoretical time is available), the vehicle is blocked or the vehicle is the last of the day (end of service).
 
-It relies on the STIB OpenData API: <https://opendata.stib-mivb.be> . It requires an access token that can be obtained for free.
-
-I wrote this module for my own usage, and it comes with no guarantee. However, I'm not opposed to fixing (small) issues or merging pull requests.
-
-## Known issue
-
-There seems to be a problem with the STIB server related to HTTP2 which prevent CORS pre-flight requests from succeding when HTTP2 is used. When using chromium, use the `--disable-http2` flag to workaround the problem.
-
-If the issue persists, we could make the requests in the node helper to bypass CORS.
+The module is updated to work with STIB OpenData API 2.1: <https://data.stib-mivb.be/>.
 
 ## Using the module
 
@@ -50,8 +42,6 @@ var config = {
 
 See below for details.
 
-
-
 ## Configuration options
 
 Option     | Description
@@ -60,16 +50,16 @@ Option     | Description
 `DisplayArrivalTime` | _Default is both_ Display actual time of arrival. It can replace waiting time or be displayed beside it.
 `timeFormat` | _Default is 24h_ Use 12h or 24h format.
 `pollInterval` | _Default is 20000_ Time between API Queries in milliseconds. Data are updated by STIB every 20 seconds - Allowed values between 20000 and 60000. 
-`stops`    | _Required_ Array of stop objects. A stop object has a freetext `name` and an `ìd` property. `id` is an array of ids for bus stops. These ids can be found in the `stops.txt` file from the STIB GTFS dataset -> <https://stibmivb.opendatasoft.com/explore/dataset/gtfs-files-production/table/>.
+`stops`    | _Required_ Array of stop objects. A stop object has a freetext `name` and an `ìd` property. `id` is an array of ids for bus stops. These ids can be found in the `stops.txt` file from the STIB GTFS dataset -> <https://stibmivb.opendatasoft.com/explore/dataset/gtfs-files-production/table/>. Be aware that in `stops.txt` some stops are listed with a stop_id ending with the letter B - copy only the numbers or the stop will be ignored by this module.
 
 
 ## STIB OpenData
 
-To create a STIB OpenData API key, go to <https://stibmivb.opendatasoft.com/> and create a free account.
+To create a STIB OpenData API key, go to <https://data.stib-mivb.be/signup/> and create a free account.
 Oncel logged in, click on your name in the top right corner of the page and then "API Keys" to generate a new key. Copy the Key value in the configuration of this module as "apiToken".
 The module can actually be used without an API key, but the STIB API limits anonymous users to 100 queries per day, so the use of an API key is necessary for production use.
 
 ## Ideas / TODO list
 
-- Scroll vertically if too many lines need to be shown (?)
 - Internationalize. Messages are currently hardcoded to French.
+- Add option to see one or two times per destination


### PR DESCRIPTION
The module works again with the new API and I am using it on my mirror, but noticed that waiting times are not always very easy to read and keep in mind, so I added options to visualize actual arrival times.

Added other options too and documented them in the README.
PollInterval is particularly useful when testing without Api key or checking the CSS on the MagicMirror page.

Merge if you like it